### PR TITLE
fixed markdown headers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,42 +1,42 @@
-#CHRYSALIS WEBSITE
+# CHRYSALIS WEBSITE
 
-#Synopsis/Description
+## Synopsis/Description
 Website for Chrysalis Medical Communications
 
-#Installation
+## Installation
 To launch, cd into root folder from terminal, type **node server.js**, and hit enter
 
-#Edit code
+## Edit code
 Launch another session of terminal, cd into root folder, type in **gulp**, and hit enter. This will allow you to make changes to the html, scss, and js files. Once you make changes, just refresh the browser to view the changes. gulpfile.js will minify js files into the js/min folder and minify the scss files into the css/styles.css file and inject the changes without you having to restart the server. If an error occurs, you may need to update using the following command: **npm install gulp-sass --save-dev**
 
-#API Reference
+## API Reference
 http://www.chrysalismedical.com/emailapi/api/email
 
-#Environments
+## Environments
 
-#Production
+## Production
 
 http://www.chrysalismedical.com
 Login credentials: N/A
 Database info (name, host, credentials): N/A
 
-#Staging
+## Staging
 http://staging.chrysalismedical.com
 Login credentials: N/A
 Database info (name, host, credentials): N/A
 
-#Authors
+## Authors
 Darryl Mendonez
 darryl.mendonez@nucleuscentral.com
 
-#Version Notes
+## Version Notes
 0.1.0
 Stakeholders wanted a revamp after seeing their initial design developed
 0.2.0
 This version breaks up the single-page site into a multi-page site as requested by stakeholders
 
-#Reusability Report
+## Reusability Report
 N/A
 
-#Code Reference
+## Code Reference
 N/A


### PR DESCRIPTION
The markdown headers need spaces between the hashes and header text, unless you are using something local that reads md differently


Will render as header on GitHub:
```
# Some Header
```

Won't render as header on GitHub:
```
#Some Header
```
